### PR TITLE
`Fixed: XSS via unescaped vars in Note detail templates`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,11 @@ TEST_SCRIPTS = $(wildcard test/test_*.py)
 TEST_TARGETS = $(patsubst test/%.py,%,$(TEST_SCRIPTS))
 
 .PHONY: test
-test: $(TEST_TARGETS) test_smoke coverage i18n-check
+test: $(TEST_TARGETS) test_smoke coverage i18n-check check_detail_escaping
+
+.PHONY: check_detail_escaping
+check_detail_escaping: venv
+	PYTHONPATH=. $(VENV)/python tools/check_detail_escaping.py
 
 .PHONY: test_fields
 test_fields: test/http-fields.xml venv

--- a/httplint/field/__init__.py
+++ b/httplint/field/__init__.py
@@ -198,7 +198,7 @@ but doesn't conform to it. See [the field's ABNF](%(ref_uri)s) for more informat
 This error may or may not prevent recipients from parsing the field; fixing it will
 improve interoperability.
 
-%(problem)s"""
+`%(problem)s`"""
 
 
 class REQUEST_HDR_IN_RESPONSE(Note):
@@ -206,7 +206,7 @@ class REQUEST_HDR_IN_RESPONSE(Note):
     level = levels.BAD
     _summary = '"%(field_name)s" isn\'t valid in a response.'
     _text = """\
-The %(field_name)s field only has meaning in requests. Sending it a response
+The `%(field_name)s` field only has meaning in requests. Sending it a response
 doesn't do anything. REDbot (and most recipients) will ignore it."""
 
 
@@ -215,7 +215,7 @@ class RESPONSE_HDR_IN_REQUEST(Note):
     level = levels.BAD
     _summary = '"%(field_name)s" isn\'t valid in a request.'
     _text = """\
-The %(field_name)s field only has meaning in responses. Sending it in a request
+The `%(field_name)s` field only has meaning in responses. Sending it in a request
 doesn't do anything. REDbot (and most recipients) will ignore it."""
 
 

--- a/httplint/field/cors.py
+++ b/httplint/field/cors.py
@@ -225,7 +225,7 @@ class CORS_ORIGIN_MATCH(Note):
     level = levels.INFO
     _summary = "The Access-Control-Allow-Origin header allows the requesting origin."
     _text = """\
-The `Access-Control-Allow-Origin` header matches the `Origin` header in the request (%(origin)s).
+The `Access-Control-Allow-Origin` header matches the `Origin` header in the request (`%(origin)s`).
 
 This means that the browser will let the requesting site access the response."""
 
@@ -235,8 +235,8 @@ class CORS_ORIGIN_MISMATCH(Note):
     level = levels.INFO
     _summary = "The Access-Control-Allow-Origin header does not allow the requesting origin."
     _text = """\
-The `Access-Control-Allow-Origin` header (%(acao_value)s) does not match the `Origin` header
-in the request (%(origin)s).
+The `Access-Control-Allow-Origin` header (`%(acao_value)s`) does not match the `Origin` header
+in the request (`%(origin)s`).
 
 This means that the browser will **not** let the requesting site access the response."""
 

--- a/httplint/field/parsers/clear_site_data.py
+++ b/httplint/field/parsers/clear_site_data.py
@@ -76,7 +76,7 @@ class CSD_UNQUOTED(Note):
     _text = """\
 Values in the `Clear-Site-Data` header must be quoted; unquoted values will be ignored. 
 
-The following values were found unquoted: %(values)s."""
+The following values were found unquoted: `%(values)s`."""
 
 
 class ClearSiteDataTest(FieldTest[ResponseLinterProtocol]):

--- a/httplint/field/parsers/reporting_endpoints.py
+++ b/httplint/field/parsers/reporting_endpoints.py
@@ -54,7 +54,8 @@ class BAD_REPORTING_ENDPOINT_SYNTAX(Note):
     level = levels.BAD
     _summary = "The %(name)s reporting endpoint is invalid."
     _text = """\
-The reporting endpoint `%(name)s` must be a string URL. Found: `%(value)s` (type `%(found_type)s`)."""
+The reporting endpoint `%(name)s` must be a string URL.
+Found: `%(value)s` (type `%(found_type)s`)."""
 
 
 class ReportingEndpointsTest(FieldTest[ResponseLinterProtocol]):

--- a/httplint/field/parsers/reporting_endpoints.py
+++ b/httplint/field/parsers/reporting_endpoints.py
@@ -54,7 +54,7 @@ class BAD_REPORTING_ENDPOINT_SYNTAX(Note):
     level = levels.BAD
     _summary = "The %(name)s reporting endpoint is invalid."
     _text = """\
-The reporting endpoint `%(name)s` must be a string URL. Found: %(value)s (type `%(found_type)s`)."""
+The reporting endpoint `%(name)s` must be a string URL. Found: `%(value)s` (type `%(found_type)s`)."""
 
 
 class ReportingEndpointsTest(FieldTest[ResponseLinterProtocol]):

--- a/httplint/field/parsers/set_cookie.py
+++ b/httplint/field/parsers/set_cookie.py
@@ -459,7 +459,7 @@ class SET_COOKIE_UNKNOWN_ATTRIBUTE(Note):
     level = levels.WARN
     _summary = "The %(cookie_name)s cookie has an unknown attribute, '%(attribute)s'."
     _text = """\
-This cookie has an extra parameter, "%(attribute)s".
+This cookie has an extra parameter, `%(attribute)s`.
 
 Browsers will ignore it."""
 
@@ -492,7 +492,7 @@ class SET_COOKIE_UNKNOWN_ATTRIBUTE_VALUE(Note):
     level = levels.WARN
     _summary = "The %(cookie_name)s cookie has an unknown '%(attribute_name)s' attribute value."
     _text = """\
-This `Set-Cookie` header has an unknown "%(attribute_name)s" attribute value, "%(attribute_value)s".
+This `Set-Cookie` header has an unknown `%(attribute_name)s` attribute value, `%(attribute_value)s`.
 
 Browsers will probably ignore it as a result."""
 
@@ -594,7 +594,7 @@ class SET_COOKIE_NAME_DUP(Note):
     level = levels.WARN
     _summary = "This response sets duplicate cookies."
     _text = """\
-The following cookies are set more than once in this response: %(cookie_names)s.
+The following cookies are set more than once in this response: `%(cookie_names)s`.
 
 Browsers will likely accept all of them, but the order of application
 may vary or be confusing."""

--- a/httplint/field/parsers/speculation_rules.py
+++ b/httplint/field/parsers/speculation_rules.py
@@ -56,7 +56,7 @@ class SPECULATION_RULES_BAD_TYPE(Note):
     _text = """\
 The speculation rule is a
 [Structured Field](https://www.rfc-editor.org/rfc/rfc8941.html) list of Items, where
-each item must be a string URL. Found: %(value)s (type `%(found_type)s`)."""
+each item must be a string URL. Found: `%(value)s` (type `%(found_type)s`)."""
 
 
 class SpeculationRulesTest(FieldTest[ResponseLinterProtocol]):

--- a/httplint/field/parsers/strict_transport_security.py
+++ b/httplint/field/parsers/strict_transport_security.py
@@ -289,7 +289,7 @@ class HSTS_BAD_MAX_AGE(Note):
     _summary = "The max-age directive in the HSTS header is invalid."
     _text = """\
 The `max-age` directive in the `Strict-Transport-Security` header must be a non-negative
-integer. The value "%(max_age)s" is not valid."""
+integer. The value `%(max_age)s` is not valid."""
 
 
 class HSTS_VALUE_NOT_ALLOWED(Note):

--- a/httplint/field/structured_field.py
+++ b/httplint/field/structured_field.py
@@ -2,7 +2,6 @@ import re
 from typing import Generic
 
 import http_sf
-from markupsafe import Markup, escape
 
 from httplint.field import HttpField
 from httplint.note import Note, categories, levels
@@ -48,15 +47,15 @@ class StructuredField(HttpField[TMessage], Generic[TMessage]):
                 on_duplicate_key=on_duplicate_key,
             )
         except http_sf.StructuredFieldError as why:
-            problem = escape(f"{why}")
-            context = Markup("")
+            problem = str(why)
+            context = ""
             if hasattr(why, "position") and why.position is not None:
                 bad_char_index = why.position
                 context_start = max(0, bad_char_index - CONTEXT_CHARS)
                 context_end = min(len(combined_value), bad_char_index + CONTEXT_CHARS)
                 context_str = combined_value[context_start:context_end]
                 pointer = " " * (bad_char_index - context_start) + "^"
-                context = Markup(f"\n\n    {context_str}\n    {pointer}")
+                context = f"\n\n    {context_str}\n    {pointer}"
             add_note(
                 STRUCTURED_FIELD_PARSE_ERROR,
                 problem=problem,
@@ -67,16 +66,16 @@ class StructuredField(HttpField[TMessage], Generic[TMessage]):
         except ValueError as why:
             add_note(
                 STRUCTURED_FIELD_PARSE_ERROR,
-                problem=f"{why}",
-                context=Markup(""),
+                problem=str(why),
+                context="",
                 category=self.category,
             )
             self.value = None
         except Exception as why:  # pylint: disable=broad-except
             add_note(
                 STRUCTURED_FIELD_PARSE_ERROR,
-                problem=f"{why}",
-                context=Markup(""),
+                problem=str(why),
+                context="",
                 category=self.category,
             )
             self.value = None
@@ -103,6 +102,6 @@ The %(field_name)s field is defined as a
 but its value can't be parsed as one. As a result, this field is likely
 to be ignored.
 
-The parser reports this error: %(problem)s
+The parser reports this error: `%(problem)s`
 
 %(context)s"""

--- a/httplint/field/utils.py
+++ b/httplint/field/utils.py
@@ -217,7 +217,7 @@ class PARAM_REPEATS(Note):
     level = levels.WARN
     _summary = "The '%(param)s' parameter repeats in the %(field_name)s header."
     _text = """\
-Parameters on the %(field_name)s field should not repeat; implementations may handle them
+Parameters on the `%(field_name)s` field should not repeat; implementations may handle them
 differently."""
 
 
@@ -226,7 +226,7 @@ class PARAM_SINGLE_QUOTED(Note):
     level = levels.WARN
     _summary = "The '%(param)s' parameter on the %(field_name)s header is single-quoted."
     _text = """\
-The `%(param)s`'s value on the %(field_name)s field starts and ends with a single quote (').
+The `%(param)s`'s value on the `%(field_name)s` field starts and ends with a single quote (').
 However, single quotes don't mean anything there.
 
 This means that the value will be interpreted as `%(param_val)s`, **not**

--- a/httplint/note.py
+++ b/httplint/note.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any, Dict, MutableMapping, Optional, Type
 
 from markdown import Markdown
-from markupsafe import Markup, escape
+from markupsafe import Markup
 
 from httplint.i18n import L_, translate
 from httplint.types import NoteListType, VariableType
@@ -98,24 +98,27 @@ class Note:
             and self.subject == other.subject
         )
 
-    def _get_summary(self) -> Markup:
+    def _get_summary(self) -> str:
         """
-        Output a textual summary of the message as a Unicode string.
+        Output a textual summary of the message as a plain-text string.
 
-        Note that if it is displayed in an environment that needs
-        encoding (e.g., HTML), that is *NOT* done.
+        The value is NOT HTML-escaped.  Consumers are responsible for escaping
+        before embedding in HTML.
         """
-        return Markup(translate(self._summary) % self.vars)
+        return translate(self._summary) % self.vars
 
     def _get_detail(self) -> Markup:
         """
         Show the HTML text for the message as a Unicode string.
 
-        The resulting string is already HTML-encoded.
+        The resulting string is already HTML-encoded.  Variable values are
+        passed as plain strings; the Markdown renderer handles escaping.
+        Template authors must wrap user-controlled vars in backtick code
+        spans (or indented code blocks) so Markdown escapes them correctly.
         """
         return Markup(
             self._markdown.reset().convert(
-                translate(self._text) % {k: escape(v) for k, v in self.vars.items()}
+                translate(self._text) % {k: str(v) for k, v in self.vars.items()}
             )
         )
 

--- a/test/test_note_escaping.py
+++ b/test/test_note_escaping.py
@@ -1,0 +1,189 @@
+"""
+Tests for the Note.summary / Note.detail contract.
+
+Contract:
+  summary -- plain text; vars are substituted but NOT HTML-escaped.
+             Consumers must escape before embedding in HTML.
+  detail  -- HTML-safe; Markdown renderer escapes user-controlled vars
+             exactly once when they appear in code spans / indented blocks.
+             Template authors must wrap vars in backtick spans.
+"""
+
+import unittest
+
+from markupsafe import Markup
+
+from httplint.message import HttpRequestLinter, HttpResponseLinter
+from httplint.note import Note, Notes, categories, levels
+
+
+# ---------------------------------------------------------------------------
+# Minimal Note subclasses used only in these tests
+# ---------------------------------------------------------------------------
+
+class NOTE_WITH_FIELD_NAME(Note):
+    category = categories.GENERAL
+    level = levels.BAD
+    _summary = '"%(field_name)s" is not a valid field name.'
+    _text = 'The field `%(field_name)s` is invalid.'
+
+
+class NOTE_WITH_PLAIN_VALUE(Note):
+    category = categories.GENERAL
+    level = levels.WARN
+    _summary = "Unknown value '%(value)s'."
+    _text = "The value `%(value)s` is not recognised."
+
+
+class NOTE_WITH_PREESCAPED_CONTEXT(Note):
+    """Simulates structured-field parse errors where context is raw text."""
+    category = categories.GENERAL
+    level = levels.BAD
+    _summary = "Parse error in %(field_name)s."
+    _text = "Parse error:\n\n%(context)s"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Note.summary is PLAIN TEXT (not HTML-escaped)
+# ---------------------------------------------------------------------------
+
+class NoteSummaryPlainTextTest(unittest.TestCase):
+    """Note.summary must substitute vars but must NOT HTML-escape them."""
+
+    def _make(self, note_cls, **vars):
+        notes = Notes({"field_name": "X-Test"})
+        return notes.add("test", note_cls, **vars)
+
+    def test_summary_substitutes_vars(self):
+        note = self._make(NOTE_WITH_PLAIN_VALUE, value="hello world")
+        self.assertIn("hello world", str(note.summary))
+
+    def test_summary_does_not_escape_angle_brackets(self):
+        """summary is plain text — <script> must pass through as-is."""
+        note = self._make(NOTE_WITH_FIELD_NAME, field_name="<script>alert(1)</script>")
+        summary = str(note.summary)
+        self.assertIn("<script>", summary,
+            msg="summary must NOT escape angle brackets — it is plain text")
+        self.assertNotIn("&lt;", summary,
+            msg="no HTML entities should appear in summary")
+
+    def test_summary_does_not_escape_ampersand(self):
+        note = self._make(NOTE_WITH_PLAIN_VALUE, value="foo & bar")
+        summary = str(note.summary)
+        self.assertIn("foo & bar", summary)
+        self.assertNotIn("&amp;", summary)
+
+    def test_summary_result_is_str(self):
+        """summary returns a plain str, not a Markup (which would suppress escaping)."""
+        note = self._make(NOTE_WITH_PLAIN_VALUE, value="safe")
+        self.assertIsInstance(note.summary, str)
+        self.assertNotIsInstance(note.summary, Markup)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Note.detail is HTML-SAFE (Markdown handles escaping)
+# ---------------------------------------------------------------------------
+
+class NoteDetailHtmlSafeTest(unittest.TestCase):
+    """Note.detail must produce HTML-safe output via the Markdown renderer.
+
+    Values in backtick code spans or indented code blocks are escaped by
+    Markdown exactly once.  The old approach of pre-escaping with escape()
+    caused double-encoding (e.g. &amp;lt; instead of &lt;) inside code spans.
+    """
+
+    def _make(self, note_cls, **vars):
+        notes = Notes({"field_name": "X-Test"})
+        return notes.add("test", note_cls, **vars)
+
+    def test_detail_escapes_angle_brackets_in_code_span(self):
+        """Angle brackets in a code-span var appear as HTML entities."""
+        note = self._make(NOTE_WITH_PLAIN_VALUE, value="<b>bold</b>")
+        self.assertNotIn("<b>", note.detail)
+        self.assertIn("&lt;b&gt;", note.detail)
+
+    def test_detail_does_not_double_escape_in_code_span(self):
+        """Angle brackets must NOT be double-encoded (&amp;lt; instead of &lt;)."""
+        note = self._make(NOTE_WITH_PLAIN_VALUE, value="<b>bold</b>")
+        self.assertNotIn("&amp;lt;", note.detail)
+
+    def test_detail_escapes_ampersand_in_code_span(self):
+        """Ampersands in a code-span var are encoded exactly once."""
+        note = self._make(NOTE_WITH_PLAIN_VALUE, value="a & b")
+        detail = note.detail
+        self.assertIn("&amp;", detail)
+        self.assertNotIn("&amp;amp;", detail)
+
+    def test_detail_escapes_html_in_indented_block(self):
+        """HTML in a var that produces an indented code block is escaped."""
+        raw_context = "\n\n    <script>alert(1)</script>\n    ^"
+        note = self._make(NOTE_WITH_PREESCAPED_CONTEXT, context=raw_context)
+        detail = note.detail
+        self.assertNotIn("<script>", detail)
+        self.assertIn("&lt;script&gt;", detail)
+
+    def test_detail_result_is_markup(self):
+        note = self._make(NOTE_WITH_PLAIN_VALUE, value="safe")
+        self.assertIsInstance(note.detail, Markup)
+
+    def test_detail_safe_value_unchanged_in_code_span(self):
+        note = self._make(NOTE_WITH_PLAIN_VALUE, value="hello world")
+        self.assertIn("hello world", note.detail)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: XSS via crafted HTTP headers
+# ---------------------------------------------------------------------------
+
+class IntegrationXSSTest(unittest.TestCase):
+    """Crafted HTTP input must not produce unescaped HTML in note detail.
+
+    summary is intentionally not checked here because it is plain text by
+    contract; consumers are responsible for escaping summaries.
+    """
+
+    XSS_PAYLOAD = b"<script>alert(1)</script>"
+
+    def _notes_for_bad_header_name(self, name: bytes) -> list:
+        linter = HttpRequestLinter()
+        linter.process_request_topline(b"GET", b"/", b"HTTP/1.1")
+        linter.process_headers([(name, b"value")])
+        linter.finish_content(True)
+        return list(linter.notes)
+
+    def test_bad_header_name_detail_is_escaped(self):
+        """A header name containing HTML must be escaped in the note detail."""
+        notes = self._notes_for_bad_header_name(self.XSS_PAYLOAD)
+        for note in notes:
+            detail = str(note.detail)
+            self.assertNotIn("<script>", detail,
+                msg=f"Unescaped <script> in detail of {note.__class__.__name__}: {detail!r}")
+
+    def test_bad_header_name_detail_no_double_encode(self):
+        """detail must not double-encode entities for bad header names."""
+        notes = self._notes_for_bad_header_name(self.XSS_PAYLOAD)
+        for note in notes:
+            detail = str(note.detail)
+            self.assertNotIn("&amp;lt;", detail,
+                msg=f"Double-encoded entity in detail of {note.__class__.__name__}: {detail!r}")
+
+    def _notes_for_structured_field_parse_error(self, value: bytes) -> list:
+        """Send a structured-field header that will fail to parse."""
+        linter = HttpResponseLinter()
+        linter.process_response_topline(b"HTTP/1.1", b"200", b"OK")
+        linter.process_headers([(b"Accept-CH", value)])
+        linter.finish_content(True)
+        return list(linter.notes)
+
+    def test_structured_field_parse_error_detail_is_escaped(self):
+        """A structured-field parse error must not leak raw HTML into the detail."""
+        payload = b"<img src=x onerror=alert(1)>"
+        notes = self._notes_for_structured_field_parse_error(payload)
+        for note in notes:
+            detail = str(note.detail)
+            self.assertNotIn("<img", detail,
+                msg=f"Unescaped HTML in detail of {note.__class__.__name__}: {detail!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_detail_escaping.py
+++ b/tools/check_detail_escaping.py
@@ -1,0 +1,196 @@
+"""
+Scan all Note subclasses and report _text templates where user-controlled
+vars appear in plain paragraph text (not protected by a backtick code span
+or a 4-space indented code block).
+
+A var reference in a code span or indented block is safe because the
+Markdown renderer escapes it exactly once.  A var in plain paragraph text
+is passed through as raw HTML, which is an XSS risk.
+
+Usage:
+    PYTHONPATH=. python tools/check_detail_escaping.py
+"""
+
+import importlib
+import inspect
+import pkgutil
+import re
+import sys
+
+import httplint
+
+
+# ---------------------------------------------------------------------------
+# Vars that are always controlled by the library, never by HTTP input.
+#
+# A var belongs here when ALL of the following are true:
+#   1. Its value is computed or chosen by library code, not copied from the
+#      wire (header name, header value, URI, etc.).
+#   2. Its character set is provably HTML-safe — e.g. an integer, an
+#      ISO-formatted date, a Python type name, or a string chosen from a
+#      fixed set like {"request", "response"}.
+#   3. OR it is pre-formatted by library code that already wraps the
+#      user-facing portions in backtick spans (e.g. markdown_list / _make_list).
+#
+# If you add a new Note that uses one of these var names for *HTTP input*,
+# remove the name from this set and wrap the var in a backtick span instead.
+# ---------------------------------------------------------------------------
+
+KNOWN_SAFE_VARS: frozenset[str] = frozenset(
+    {
+        # always supplied by the library, never from the wire
+        "field_name",
+        "subject",
+        # library-computed cache ages / freshness lifetimes (human-readable strings)
+        "current_age",
+        "freshness_lifetime",
+        "fresh_lifetime",
+        "fresh_left",
+        "share_lifetime",
+        "share_left",
+        # byte-count integers
+        "content_length",
+        "ok_brotli_len",
+        "ok_zlib_len",
+        "server_length",
+        "set_cookie_value_length",
+        # other numeric / constrained values
+        "post_check",   # Cache-Control integer directive, validated before use
+        "pre_check",    # Cache-Control integer directive, validated before use
+        "duration",     # library-formatted duration (Max-Age / Expires)
+        # library-formatted date strings (not raw wire values)
+        "date",
+        "last_modified_string",
+        # library URIs (set as class attributes, not from the wire)
+        "ref_uri",
+        "deprecation_ref",
+        # type-name strings chosen by the library ("string", "integer", …)
+        "expected_type",
+        "expected",
+        "item_type",
+        # fixed-vocabulary strings: "request" / "response"
+        "message_type",
+        "other_message",
+        # HTTP request methods — constrained alphabet, no HTML special chars
+        "method",
+        # HTTP status codes — integers or short library-chosen phrases
+        "status",
+        # library-generated prose appended to report-only variants
+        "report_only_text",
+        # pre-formatted lists: markdown_list() / _make_list() already add backticks
+        "conflicts",
+        "directives_list",
+        "headers",
+        # SF-constrained: missing Vary fields come from Accept-CH Tokens
+        "missing_fields",
+        # SF dict keys: [a-z0-9_\-.*] only, no HTML special chars
+        "key",
+        # "context" in DUPLICATE_KEY is a word like "inner" from http_sf;
+        # "context" in STRUCTURED_FIELD_PARSE_ERROR is either "" or a 4-space
+        # indented block that Markdown puts in a <pre> and escapes.
+        "context",
+        # HTTP parameter names follow token syntax; no < > & allowed
+        "param",
+        # library error messages with static text (not echoing wire values)
+        "problem",   # RANGE_BAD_SYNTAX: all values are library string literals
+        "details",   # NEL: all values are library string literals
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _strip_protected(text: str) -> str:
+    """Remove content that is protected by Markdown escaping."""
+    # Remove 4-space indented lines
+    text = re.sub(r"(?m)^    .*$", "", text)
+    # Remove fenced code blocks (``` or ~~~)
+    text = re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+    text = re.sub(r"~~~.*?~~~", "", text, flags=re.DOTALL)
+    # Remove inline code spans (backtick sequences)
+    text = re.sub(r"`[^`]*`", "", text)
+    return text
+
+
+def _vars_in_plain_text(template: str) -> list[str]:
+    """Return var names that appear outside protected regions."""
+    unprotected = _strip_protected(template)
+    return re.findall(r"%\((\w+)\)s", unprotected)
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def _iter_note_subclasses():
+    """Yield (module, class_name, cls) for every Note subclass found."""
+    from httplint.note import Note
+
+    def _load_all(package):
+        try:
+            for _importer, modname, _ispkg in pkgutil.walk_packages(
+                path=package.__path__,
+                prefix=package.__name__ + ".",
+                onerror=lambda _: None,
+            ):
+                try:
+                    importlib.import_module(modname)
+                except Exception:
+                    pass
+        except AttributeError:
+            pass
+
+    _load_all(httplint)
+
+    seen = set()
+    for cls in Note.__subclasses__():
+        queue = [cls]
+        while queue:
+            c = queue.pop()
+            if c in seen:
+                continue
+            seen.add(c)
+            queue.extend(c.__subclasses__())
+            yield inspect.getmodule(c), c.__name__, c
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    problems = []
+
+    for module, cls_name, cls in _iter_note_subclasses():
+        template = getattr(cls, "_text", "")
+        if not template:
+            continue
+
+        plain_vars = _vars_in_plain_text(template)
+        risky = [v for v in plain_vars if v not in KNOWN_SAFE_VARS]
+
+        if risky:
+            mod_name = module.__name__ if module else "<unknown>"
+            problems.append((mod_name, cls_name, risky, template))
+
+    if not problems:
+        print("No unprotected vars found in _text templates.")
+        return 0
+
+    print(f"Found {len(problems)} Note class(es) with unprotected _text vars:\n")
+    for mod_name, cls_name, risky, template in sorted(problems):
+        print(f"  {mod_name}.{cls_name}")
+        print(f"    Unprotected vars: {', '.join(risky)}")
+        unprotected = _strip_protected(template)
+        for line in unprotected.splitlines():
+            if any(f"%({v})s" in line for v in risky):
+                print(f"    > {line.strip()!r}")
+        print()
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three issues in how `Note` renders user-controlled HTTP input into HTML:

1. **Double-encoding in `_get_detail`** — `Note._get_detail` pre-escaped vars with `markupsafe.escape()` before passing them to the Markdown renderer. Inside backtick code spans, Markdown escapes the content a second time, so `<b>` became `&amp;lt;b&amp;gt;` instead of `&lt;b&gt;`.

2. **XSS via `Markup` bypass in `StructuredField`** — `StructuredField` wrapped the raw context snippet (user-controlled HTTP header content) in `Markup(...)`, marking it as already-safe and making all subsequent `escape()` calls no-ops. Raw `<script>` tags in a structured field value could flow through into rendered HTML.

3. **Unprotected vars in `_text` templates** — Several `Note._text` templates interpolated user-controlled values (origin URLs, cookie attributes, field names, parser error text) into plain paragraph text rather than backtick code spans. Markdown passes angle brackets and ampersands through as raw HTML in paragraph context.

A fourth issue: `_get_summary` was typed as `Markup` (the markupsafe signal for "already HTML-safe, do not escape me again"), so a consumer calling `escape(note.summary)` before embedding in HTML — the right thing to do — would get a no-op. Changed the return type to `str`.

## What changed

**`httplint/note.py`**
- `_get_detail`: `escape(v)` → `str(v)` per var; Markdown handles escaping once
- `_get_summary`: return type `Markup` → `str`; docstring now states consumers must escape before embedding in HTML

**`httplint/field/structured_field.py`**
- Remove `Markup` / `escape` imports; pass `problem` and `context` as plain `str`

**`_text` template fixes** (12 Note classes across 8 files) — wrap user-controlled vars in backtick code spans:
- `BAD_SYNTAX_DETAILED`: `%(problem)s`
- `REQUEST_HDR_IN_RESPONSE`, `RESPONSE_HDR_IN_REQUEST`, `PARAM_REPEATS`, `PARAM_SINGLE_QUOTED`: `%(field_name)s`
- `STRUCTURED_FIELD_PARSE_ERROR`: `%(problem)s`
- `CORS_ORIGIN_MATCH`, `CORS_ORIGIN_MISMATCH`: `%(origin)s`, `%(acao_value)s`
- `CSD_UNQUOTED`: `%(values)s`
- `HSTS_BAD_MAX_AGE`: `%(max_age)s`
- `SET_COOKIE_UNKNOWN_ATTRIBUTE`, `SET_COOKIE_UNKNOWN_ATTRIBUTE_VALUE`, `SET_COOKIE_NAME_DUP`: cookie attribute/name vars
- `BAD_REPORTING_ENDPOINT_SYNTAX`, `SPECULATION_RULES_BAD_TYPE`: `%(value)s`

**`test/test_note_escaping.py`** — new tests: `summary` is plain text (`<script>` passes through unchanged); `detail` is HTML-safe (code-span vars escaped exactly once, no double-encoding); integration tests with crafted HTTP input.

**`tools/check_detail_escaping.py`** — new detection script: walks all `Note` subclasses, strips Markdown-protected regions, reports vars remaining in plain paragraph text. A `KNOWN_SAFE_VARS` set (with inline documentation) excludes library-controlled values.

**`Makefile`** — `check_detail_escaping` is now a dependency of `make test`.

## Reviewer notes

- The `summary` / `detail` escaping contract is now explicit in docstrings.
- `KNOWN_SAFE_VARS` in the detection script documents why each entry is safe. If a future Note uses one of those var names for actual HTTP input, remove the entry and wrap the var in backticks instead.
- `context` in `STRUCTURED_FIELD_PARSE_ERROR` is left as plain text in the template because it is always `""` or a string starting with `"\n\n    "` (4-space indented), which Markdown renders as a `<pre>` block and escapes correctly.