### PR TITLE
Claude/silly poincare f6b902

### DIFF
--- a/httplint/field/parsers/clear_site_data.py
+++ b/httplint/field/parsers/clear_site_data.py
@@ -50,6 +50,22 @@ origin."""
             add_note(CSD_UNQUOTED, values=", ".join(self._unquoted_values))
         if not self.value:
             add_note(CSD_EMPTY)
+            return
+        valid = [v for v in self.value if v in self.KNOWN_VALUES and v not in self._unquoted_values]
+        if valid:
+            add_note(CSD_PRESENT, values=", ".join(f"`{v}`" for v in valid))
+
+
+class CSD_PRESENT(Note):
+    category = categories.SECURITY
+    level = levels.GOOD
+    _summary = "This response clears browser-side data for this origin."
+    _text = """\
+The `Clear-Site-Data` header instructs the browser to clear the following data for this origin:
+%(values)s.
+
+This is useful for actions such as logout, account switching, or session termination, where
+locally-stored data should not persist."""
 
 
 class CSD_UNKNOWN_VALUE(Note):
@@ -83,12 +99,14 @@ class ClearSiteDataTest(FieldTest[ResponseLinterProtocol]):
     name = "Clear-Site-Data"
     inputs = [b'"cache", "cookies"']
     expected_out = ["cache", "cookies"]
+    expected_notes: NoteClassListType = [CSD_PRESENT]
 
 
 class ClearSiteDataWildcardTest(FieldTest[ResponseLinterProtocol]):
     name = "Clear-Site-Data"
     inputs = [b'"*"']
     expected_out = ["*"]
+    expected_notes: NoteClassListType = [CSD_PRESENT]
 
 
 class ClearSiteDataUnknownTest(FieldTest[ResponseLinterProtocol]):

--- a/httplint/field/parsers/cross_origin_resource_policy.py
+++ b/httplint/field/parsers/cross_origin_resource_policy.py
@@ -39,7 +39,7 @@ loaded by a cross-origin document."""
 
 class CORP_SAME_ORIGIN(Note):
     category = categories.SECURITY
-    level = levels.INFO
+    level = levels.GOOD
     _summary = "This response is only available for reading to requests from the same origin."
     _text = """\
 The `same-origin`
@@ -50,7 +50,7 @@ in supporting browsers.%(report_only_text)s"""
 
 class CORP_SAME_SITE(Note):
     category = categories.SECURITY
-    level = levels.INFO
+    level = levels.GOOD
     _summary = "This response is available for reading to requests from the same site."
     _text = """\
 The `same-site`

--- a/httplint/field/parsers/link.py
+++ b/httplint/field/parsers/link.py
@@ -70,10 +70,17 @@ statement of the form "[context IRI] has a [relation type] resource at [target I
         present = {k: v for k, v in hints.items() if v}
         if present:
             hints_plain = ", ".join(present)
-            detail_lines = "\n".join(
-                f"- `{k}`: {', '.join(f'`{t}`' for t in targets)}" for k, targets in present.items()
+            # Strip backticks so attacker-controlled link targets cannot escape
+            # the surrounding code span and inject raw HTML via Markdown.
+            lines = []
+            for rel_name, targets in present.items():
+                safe = [t.replace("`", "") for t in targets]
+                lines.append(f"- `{rel_name}`: {', '.join(f'`{t}`' for t in safe)}")
+            add_note(
+                LINK_RESOURCE_HINTS,
+                hints=hints_plain,
+                detail_lines="\n".join(lines),
             )
-            add_note(LINK_RESOURCE_HINTS, hints=hints_plain, detail_lines=detail_lines)
 
 
 class LINK_RESOURCE_HINTS(Note):

--- a/httplint/field/parsers/link.py
+++ b/httplint/field/parsers/link.py
@@ -1,5 +1,6 @@
 import re
 from typing import Tuple
+from urllib.parse import urljoin, urlsplit
 
 from httplint.field import BAD_SYNTAX
 from httplint.field.list_field import HttpListField
@@ -45,6 +46,59 @@ statement of the form "[context IRI] has a [relation type] resource at [target I
             if not re.match(rf"^\s*{rfc9110.media_type}\s*$", param_dict["type"], re.VERBOSE):
                 add_note(LINK_BAD_TYPE, link=link_value, type=param_dict["type"])
         return link_value, param_dict
+
+    def evaluate(self, add_note: AddNoteMethodType) -> None:
+        hints: dict[str, list[str]] = {"preload": [], "preconnect": [], "dns-prefetch": []}
+        bad_targets: list[Tuple[str, str, str]] = []  # (rel, link, scheme)
+        base_uri = getattr(self.message, "base_uri", "") or ""
+        for link_value, params in self.value:
+            rel = params.get("rel")
+            if not isinstance(rel, str):
+                continue
+            for token in rel.lower().split():
+                if token not in hints:
+                    continue
+                scheme = urlsplit(urljoin(base_uri, link_value)).scheme.lower()
+                if scheme and scheme not in ("http", "https"):
+                    bad_targets.append((token, link_value, scheme))
+                else:
+                    hints[token].append(link_value)
+
+        for rel_name, link_value, scheme in bad_targets:
+            add_note(LINK_BAD_HINT_TARGET, rel=rel_name, link=link_value, scheme=scheme)
+
+        present = {k: v for k, v in hints.items() if v}
+        if present:
+            hints_plain = ", ".join(present)
+            detail_lines = "\n".join(
+                f"- `{k}`: {', '.join(f'`{t}`' for t in targets)}" for k, targets in present.items()
+            )
+            add_note(LINK_RESOURCE_HINTS, hints=hints_plain, detail_lines=detail_lines)
+
+
+class LINK_RESOURCE_HINTS(Note):
+    category = categories.GENERAL
+    level = levels.GOOD
+    _summary = "This response provides resource hints (%(hints)s)."
+    _text = """\
+The `Link` header advertises the following
+[resource hints](https://www.w3.org/TR/resource-hints/), allowing the client to begin work on
+related resources before the current response is fully processed:
+
+%(detail_lines)s
+
+`preload` triggers the browser to fetch a resource needed for the current page; `preconnect`
+opens a connection (DNS + TCP + TLS) to an origin in advance; `dns-prefetch` performs a DNS
+lookup only. Used appropriately, these hints can reduce critical-path latency."""
+
+
+class LINK_BAD_HINT_TARGET(Note):
+    category = categories.GENERAL
+    level = levels.WARN
+    _summary = "The %(rel)s Link target uses an unsupported scheme."
+    _text = """\
+The `Link` header advertises a `%(rel)s` resource hint for `%(link)s`, but its scheme
+(`%(scheme)s`) is not `http` or `https`. Browsers will ignore this hint."""
 
 
 class LINK_REV(Note):
@@ -132,3 +186,71 @@ class BadTypeLinkTest(FieldTest[AnyMessageLinterProtocol]):
     inputs = [b'</foo>; rel="bar"; type="{blah}"']
     expected_out = [("/foo", {"rel": "bar", "type": "{blah}"})]
     expected_notes: NoteClassListType = [LINK_BAD_TYPE]
+
+
+class PreloadLinkTest(FieldTest[AnyMessageLinterProtocol]):
+    name = "Link"
+    inputs = [b'</main.css>; rel="preload"; as="style"']
+    expected_out = [("/main.css", {"rel": "preload", "as": "style"})]
+    expected_notes: NoteClassListType = [LINK_RESOURCE_HINTS]
+
+
+class PreconnectLinkTest(FieldTest[AnyMessageLinterProtocol]):
+    name = "Link"
+    inputs = [b'<https://cdn.example.com>; rel="preconnect"']
+    expected_out = [("https://cdn.example.com", {"rel": "preconnect"})]
+    expected_notes: NoteClassListType = [LINK_RESOURCE_HINTS]
+
+
+class DnsPrefetchLinkTest(FieldTest[AnyMessageLinterProtocol]):
+    name = "Link"
+    inputs = [b'<https://cdn.example.com>; rel="dns-prefetch"']
+    expected_out = [("https://cdn.example.com", {"rel": "dns-prefetch"})]
+    expected_notes: NoteClassListType = [LINK_RESOURCE_HINTS]
+
+
+class MultipleHintsLinkTest(FieldTest[AnyMessageLinterProtocol]):
+    name = "Link"
+    inputs = [
+        b'</main.css>; rel="preload"; as="style"',
+        b'<https://cdn.example.com>; rel="preconnect"',
+    ]
+    expected_out = [
+        ("/main.css", {"rel": "preload", "as": "style"}),
+        ("https://cdn.example.com", {"rel": "preconnect"}),
+    ]
+    expected_notes: NoteClassListType = [LINK_RESOURCE_HINTS]
+
+
+class CombinedRelHintLinkTest(FieldTest[AnyMessageLinterProtocol]):
+    name = "Link"
+    inputs = [b'<https://cdn.example.com>; rel="preconnect dns-prefetch"']
+    expected_out = [("https://cdn.example.com", {"rel": "preconnect dns-prefetch"})]
+    expected_notes: NoteClassListType = [LINK_RESOURCE_HINTS]
+
+
+class NonHintLinkTest(FieldTest[AnyMessageLinterProtocol]):
+    name = "Link"
+    inputs = [b'</style.css>; rel="stylesheet"']
+    expected_out = [("/style.css", {"rel": "stylesheet"})]
+    expected_notes: NoteClassListType = []
+
+
+class BadHintTargetLinkTest(FieldTest[AnyMessageLinterProtocol]):
+    name = "Link"
+    inputs = [b'<javascript:alert(1)>; rel="preload"']
+    expected_out = [("javascript:alert(1)", {"rel": "preload"})]
+    expected_notes: NoteClassListType = [LINK_BAD_HINT_TARGET]
+
+
+class MixedHintTargetsLinkTest(FieldTest[AnyMessageLinterProtocol]):
+    name = "Link"
+    inputs = [
+        b'<https://cdn.example.com>; rel="preconnect"',
+        b'<ftp://example.com/x>; rel="preload"',
+    ]
+    expected_out = [
+        ("https://cdn.example.com", {"rel": "preconnect"}),
+        ("ftp://example.com/x", {"rel": "preload"}),
+    ]
+    expected_notes: NoteClassListType = [LINK_RESOURCE_HINTS, LINK_BAD_HINT_TARGET]

--- a/httplint/field/parsers/nel.py
+++ b/httplint/field/parsers/nel.py
@@ -1,4 +1,8 @@
+from typing import Any, List, Set
+from urllib.parse import urljoin, urlsplit
+
 from httplint.field.json_field import BAD_JSON, JsonField
+from httplint.field.parsers.reporting_endpoints import ENDPOINT_NOT_SECURE
 from httplint.field.tests import FieldTest
 from httplint.note import Note, categories, levels
 from httplint.types import (
@@ -6,6 +10,21 @@ from httplint.types import (
     NoteClassListType,
     ResponseLinterProtocol,
 )
+
+
+def _valid_reporting_endpoints(field_value: Any, base_uri: str) -> Set[str]:
+    """Names of reporting endpoints that are well-formed and use a secure scheme."""
+    valid: Set[str] = set()
+    for name, item in field_value.items():
+        url = item[0]
+        if not isinstance(url, str):
+            continue
+        target = urljoin(base_uri, url)
+        scheme = urlsplit(target).scheme.lower()
+        if scheme and scheme not in ("https", "wss"):
+            continue
+        valid.add(name)
+    return valid
 
 
 class nel(JsonField[ResponseLinterProtocol]):
@@ -16,6 +35,10 @@ It allows websites to declare that they want to receive reports about network er
     reference = "https://w3c.github.io/network-error-logging/#nel-header-field"
     deprecated = False
 
+    def __init__(self, wire_name: str, message: ResponseLinterProtocol) -> None:
+        super().__init__(wire_name, message)
+        self._clean_policies: List[bool] = []
+
     def evaluate(self, add_note: AddNoteMethodType) -> None:
         if self.value is None:
             return
@@ -25,46 +48,60 @@ It allows websites to declare that they want to receive reports about network er
         for policy in self.value:
             if not isinstance(policy, dict):
                 add_note(NEL_BAD_STRUCTURE)
+                self._clean_policies.append(False)
                 continue
+
+            clean = True
 
             # report_to
             if "report_to" not in policy:
                 add_note(NEL_MISSING_KEY, key="report_to")
+                clean = False
             elif not isinstance(policy["report_to"], str):
                 add_note(NEL_BAD_TYPE, key="report_to", expected="string")
+                clean = False
 
             # max_age needed
             # "If `max_age` member is missing ... user agent MUST ignore the policy."
             if "max_age" not in policy:
                 add_note(NEL_MISSING_KEY, key="max_age")
+                clean = False
             elif not isinstance(policy["max_age"], int):
                 add_note(NEL_BAD_TYPE, key="max_age", expected="integer")
+                clean = False
 
             # optional members
             if "include_subdomains" in policy and not isinstance(
                 policy["include_subdomains"], bool
             ):
                 add_note(NEL_BAD_TYPE, key="include_subdomains", expected="boolean")
+                clean = False
 
             if "success_fraction" in policy:
                 if not isinstance(policy["success_fraction"], (int, float)):
                     add_note(NEL_BAD_TYPE, key="success_fraction", expected="number")
+                    clean = False
                 elif not 0.0 <= policy["success_fraction"] <= 1.0:
                     add_note(
                         NEL_BAD_VALUE,
                         key="success_fraction",
                         details="itmust be between 0.0 and 1.0",
                     )
+                    clean = False
 
             if "failure_fraction" in policy:
                 if not isinstance(policy["failure_fraction"], (int, float)):
                     add_note(NEL_BAD_TYPE, key="failure_fraction", expected="number")
+                    clean = False
                 elif not 0.0 <= policy["failure_fraction"] <= 1.0:
                     add_note(
                         NEL_BAD_VALUE,
                         key="failure_fraction",
                         details="it must be between 0.0 and 1.0",
                     )
+                    clean = False
+
+            self._clean_policies.append(clean)
 
     def post_check(self, add_note: AddNoteMethodType) -> None:
         if not self.value:
@@ -75,14 +112,28 @@ It allows websites to declare that they want to receive reports about network er
             list(reporting_endpoints_field.keys()) if reporting_endpoints_field else []
         )
         known_endpoints = set(reporting_endpoints)
+        valid_endpoints = (
+            _valid_reporting_endpoints(reporting_endpoints_field, self.message.base_uri)
+            if reporting_endpoints_field
+            else set()
+        )
 
-        for policy in self.value:
+        resolved_endpoints = []
+        for idx, policy in enumerate(self.value):
             if not isinstance(policy, dict):
                 continue
             report_to = policy.get("report_to")
             if report_to and isinstance(report_to, str):
                 if report_to not in known_endpoints:
                     add_note(NEL_REPORT_TO_MISSING, key="report_to", value=report_to)
+                elif report_to in valid_endpoints and self._clean_policies[idx]:
+                    resolved_endpoints.append(report_to)
+
+        if resolved_endpoints:
+            add_note(
+                NEL_CONFIGURED,
+                endpoints=", ".join(f"`{e}`" for e in resolved_endpoints),
+            )
 
 
 class NEL_BAD_STRUCTURE(Note):
@@ -119,6 +170,19 @@ The `%(key)s` key has an invalid value; %(details)s.
 Details: %(details)s"""
 
 
+class NEL_CONFIGURED(Note):
+    category = categories.GENERAL
+    level = levels.GOOD
+    _summary = "Network Error Logging is configured for this response."
+    _text = """\
+The `NEL` header configures
+[Network Error Logging](https://w3c.github.io/network-error-logging/), which instructs the browser
+to report network-level errors (DNS, TCP, TLS, and HTTP failures) to the reporting endpoint(s):
+%(endpoints)s.
+
+This supports observability of failures that would otherwise be invisible to the server."""
+
+
 class NEL_REPORT_TO_MISSING(Note):
     category = categories.GENERAL
     level = levels.WARN
@@ -143,7 +207,7 @@ class NelTest(FieldTest[ResponseLinterProtocol]):
             "success_fraction": 0.5,
         }
     ]
-    expected_notes: NoteClassListType = []
+    expected_notes: NoteClassListType = [NEL_CONFIGURED]
 
     def set_response_context(self, message: ResponseLinterProtocol) -> None:
         message.headers.process([(b"Reporting-Endpoints", b'group1="https://example.com/reports"')])
@@ -159,7 +223,7 @@ class NelMultiLineTest(FieldTest[ResponseLinterProtocol]):
         {"report_to": "group1", "max_age": 2592000},
         {"report_to": "group2", "max_age": 3600},
     ]
-    expected_notes: NoteClassListType = []
+    expected_notes: NoteClassListType = [NEL_CONFIGURED]
 
     def set_response_context(self, message: ResponseLinterProtocol) -> None:
         message.headers.process(
@@ -201,7 +265,7 @@ class NelReportToTest(FieldTest[ResponseLinterProtocol]):
     name = "NEL"
     inputs = [b'{"report_to": "group1", "max_age": 100}']
     expected_out = [{"report_to": "group1", "max_age": 100}]
-    expected_notes: NoteClassListType = []
+    expected_notes: NoteClassListType = [NEL_CONFIGURED]
 
     def set_response_context(self, message: ResponseLinterProtocol) -> None:
         message.headers.process([(b"Reporting-Endpoints", b'group1="https://example.com/reports"')])
@@ -212,3 +276,13 @@ class NelReportToMissingTest(FieldTest[ResponseLinterProtocol]):
     inputs = [b'{"report_to": "group1", "max_age": 100}']
     expected_out = [{"report_to": "group1", "max_age": 100}]
     expected_notes: NoteClassListType = [NEL_REPORT_TO_MISSING]
+
+
+class NelReportToInsecureTest(FieldTest[ResponseLinterProtocol]):
+    name = "NEL"
+    inputs = [b'{"report_to": "group1", "max_age": 100}']
+    expected_out = [{"report_to": "group1", "max_age": 100}]
+    expected_notes: NoteClassListType = [ENDPOINT_NOT_SECURE]
+
+    def set_response_context(self, message: ResponseLinterProtocol) -> None:
+        message.headers.process([(b"Reporting-Endpoints", b'group1="http://example.com/reports"')])

--- a/httplint/field/parsers/referrer_policy.py
+++ b/httplint/field/parsers/referrer_policy.py
@@ -36,6 +36,18 @@ header) should be included with requests."""
         effective_policy = valid_policies[-1]
         if effective_policy == "unsafe-url":
             add_note(REFERRER_POLICY_UNSAFE)
+        elif effective_policy in STRICT_REFERRER_POLICIES:
+            add_note(REFERRER_POLICY_STRICT, policy=effective_policy)
+
+
+class REFERRER_POLICY_STRICT(Note):
+    category = categories.SECURITY
+    level = levels.GOOD
+    _summary = "This response's Referrer-Policy ('%(policy)s') restricts referrer leakage."
+    _text = """\
+The `Referrer-Policy` value `%(policy)s` prevents the full URL from being sent as a referrer to
+less-secure or cross-origin destinations, reducing the risk of leaking sensitive information in
+the `Referer` request header."""
 
 
 class REFERRER_POLICY_UNSAFE(Note):
@@ -75,6 +87,14 @@ The `Referrer-Policy` header contains multiple valid policies. Browsers will onl
 valid policy found, which is `%(effective)s`. Earlier values are ignored."""
 
 
+STRICT_REFERRER_POLICIES = {
+    "no-referrer",
+    "same-origin",
+    "strict-origin",
+    "strict-origin-when-cross-origin",
+}
+
+
 VALID_REFERRER_POLICIES = [
     "no-referrer",
     "no-referrer-when-downgrade",
@@ -94,6 +114,13 @@ class ReferrerPolicyTest(FieldTest[ResponseLinterProtocol]):
     expected_notes: NoteClassListType = [REFERRER_POLICY_UNSAFE, REFERRER_POLICY_MULTIPLE]
 
 
+class ReferrerPolicyStrictTest(FieldTest[ResponseLinterProtocol]):
+    name = "Referrer-Policy"
+    inputs = [b"strict-origin-when-cross-origin"]
+    expected_out = ["strict-origin-when-cross-origin"]
+    expected_notes: NoteClassListType = [REFERRER_POLICY_STRICT]
+
+
 class ReferrerPolicyUnknownTest(FieldTest[ResponseLinterProtocol]):
     name = "Referrer-Policy"
     inputs = [b"unknown-value"]
@@ -105,4 +132,4 @@ class ReferrerPolicyOverrideTest(FieldTest[ResponseLinterProtocol]):
     name = "Referrer-Policy"
     inputs = [b"unsafe-url, no-referrer"]
     expected_out = ["unsafe-url", "no-referrer"]
-    expected_notes: NoteClassListType = [REFERRER_POLICY_MULTIPLE]
+    expected_notes: NoteClassListType = [REFERRER_POLICY_MULTIPLE, REFERRER_POLICY_STRICT]

--- a/httplint/field/parsers/set_cookie.py
+++ b/httplint/field/parsers/set_cookie.py
@@ -56,8 +56,22 @@ requests to the server."""
                 seen.add(name)
             add_note(SET_COOKIE_NAME_DUP, cookie_names=", ".join(sorted(duplicates)))
 
+        hardened = [name for name, _, attrs in self.value if _is_hardened(attrs)]
+        if hardened:
+            add_note(
+                SET_COOKIE_HARDENED,
+                cookie_names=", ".join(f"`{n}`" for n in hardened),
+            )
+
         for note_adder, note, category, kwargs in self._deferred_notes:
             note_adder(note, category=category, **kwargs)
+
+
+def _is_hardened(attrs: List[Tuple[str, Union[str, int]]]) -> bool:
+    has_secure = ("Secure", "") in attrs
+    has_httponly = ("HttpOnly", "") in attrs
+    has_safe_samesite = any(k == "SameSite" and v in ("Strict", "Lax") for k, v in attrs)
+    return has_secure and has_httponly and has_safe_samesite
 
 
 def loose_parse(  # pylint: disable=too-many-branches
@@ -589,6 +603,18 @@ The `%(attribute)s` attribute appears more than once in this `Set-Cookie` header
 Browsers will only use the last occurrence."""
 
 
+class SET_COOKIE_HARDENED(Note):
+    category = categories.COOKIES
+    level = levels.GOOD
+    _summary = "This response sets cookies restricted with Secure, HttpOnly, and SameSite."
+    _text = """\
+The following cookies set `Secure` (only sent over HTTPS), `HttpOnly` (inaccessible to
+JavaScript), and a non-`None` `SameSite` value (limiting cross-site sending): %(cookie_names)s.
+
+Together, these attributes substantially reduce a cookie's exposure to common attacks such as
+theft over plaintext connections, cross-site scripting, and cross-site request forgery."""
+
+
 class SET_COOKIE_NAME_DUP(Note):
     category = categories.COOKIES
     level = levels.WARN
@@ -773,6 +799,23 @@ class SetCookiePriorityTest(FieldTest[ResponseLinterProtocol]):
     inputs = [b"a=1; Priority=High"]
     expected_out = [("a", "1", [])]
     expected_notes: NoteClassListType = [SET_COOKIE_PRIORITY]
+
+
+class HardenedSCTest(FieldTest[ResponseLinterProtocol]):
+    name = "Set-Cookie"
+    inputs = [b"SID=abc; Secure; HttpOnly; SameSite=Lax"]
+    expected_out = [
+        ("SID", "abc", [("Secure", ""), ("HttpOnly", ""), ("SameSite", "Lax")]),
+    ]
+    expected_notes: NoteClassListType = [SET_COOKIE_HARDENED]
+
+
+class HardenedSameSiteNoneSCTest(FieldTest[ResponseLinterProtocol]):
+    name = "Set-Cookie"
+    inputs = [b"SID=abc; Secure; HttpOnly; SameSite=None"]
+    expected_out = [
+        ("SID", "abc", [("Secure", ""), ("HttpOnly", ""), ("SameSite", "None")]),
+    ]
 
 
 class SetCookieVersionTest(FieldTest[ResponseLinterProtocol]):

--- a/httplint/field/parsers/set_cookie.py
+++ b/httplint/field/parsers/set_cookie.py
@@ -58,9 +58,11 @@ requests to the server."""
 
         hardened = [name for name, _, attrs in self.value if _is_hardened(attrs)]
         if hardened:
+            # Strip backticks so attacker-controlled cookie names cannot escape
+            # the surrounding code span and inject raw HTML via Markdown.
             add_note(
                 SET_COOKIE_HARDENED,
-                cookie_names=", ".join(f"`{n}`" for n in hardened),
+                cookie_names=", ".join(f"`{n.replace('`', '')}`" for n in hardened),
             )
 
         for note_adder, note, category, kwargs in self._deferred_notes:

--- a/httplint/field/parsers/x_frame_options.py
+++ b/httplint/field/parsers/x_frame_options.py
@@ -46,14 +46,16 @@ the transmitted content in frames that are part of other web pages.
 
 class FRAME_OPTIONS_DENY(Note):
     category = categories.SECURITY
-    level = levels.INFO
-    _summary = "This response prevents some browsers from rendering it within a frame."
-    # Original URL:
-    # http://blogs.msdn.com/b/ie/archive/2009/01/27/ie8-security-part-vii-clickjacking-defenses.aspx
+    level = levels.GOOD
+    _summary = "This response prevents browsers from rendering it within a frame."
     _text = """\
-The `X-Frame-Options` response header controls how IE8 handles HTML frames; the `DENY` value
-prevents this content from being rendered within a frame, which defends against certain types of
-attacks.
+The `DENY` value of `X-Frame-Options` prevents this content from being rendered within a frame,
+defending against clickjacking-style attacks.
+
+Note that `X-Frame-Options` has been superseded by the
+[`frame-ancestors`](https://www.w3.org/TR/CSP3/#directive-frame-ancestors) directive of
+`Content-Security-Policy`, which offers finer-grained control and is the modern equivalent.
+If both are present, browsers that support CSP will use `frame-ancestors` and ignore this header.
 
 See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) for more information.
 """
@@ -61,18 +63,16 @@ See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Opti
 
 class FRAME_OPTIONS_SAMEORIGIN(Note):
     category = categories.SECURITY
-    level = levels.INFO
-    _summary = (
-        "This response prevents some browsers from rendering it within a frame on another site."
-    )
-    # Original URL:
-    # http://blogs.msdn.com/b/ie/archive/2009/01/27/ie8-security-part-vii-clickjacking-defenses.aspx
+    level = levels.GOOD
+    _summary = "This response prevents browsers from rendering it within a frame on another site."
     _text = """\
-The `X-Frame-Options` response header controls how IE8 handles HTML frames; the `DENY` value
-prevents this content from being rendered within a frame on another site, which defends against
-certain types of attacks.
+The `SAMEORIGIN` value of `X-Frame-Options` prevents this content from being rendered within a
+frame on a different origin, defending against clickjacking-style attacks.
 
-Currently this is supported by IE8 and Safari 4.
+Note that `X-Frame-Options` has been superseded by the
+[`frame-ancestors`](https://www.w3.org/TR/CSP3/#directive-frame-ancestors) directive of
+`Content-Security-Policy`, which offers finer-grained control and is the modern equivalent.
+If both are present, browsers that support CSP will use `frame-ancestors` and ignore this header.
 
 See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options) for more information.
 """

--- a/tools/check_detail_escaping.py
+++ b/tools/check_detail_escaping.py
@@ -81,6 +81,21 @@ KNOWN_SAFE_VARS: frozenset[str] = frozenset(
         "conflicts",
         "directives_list",
         "headers",
+        # Clear-Site-Data directive names: closed set ({cache, cookies, storage,
+        # executionContexts, *}); each item is wrapped in a backtick span.
+        "values",
+        # Reporting-Endpoints names: SF dictionary keys (same alphabet as `key`);
+        # each item is wrapped in a backtick span.
+        "endpoints",
+        # Set-Cookie cookie-name: attacker-controlled (loose_parse does not enforce
+        # tchar). Library strips backticks before wrapping each name in a span; the
+        # markdown renderer HTML-escapes <, >, & inside code spans, so the value
+        # cannot escape the span.
+        "cookie_names",
+        # Link resource-hint markdown list: rel tokens are from a closed set; link
+        # targets are attacker-controlled, but library strips backticks before
+        # wrapping each target in a code span (see cookie_names justification).
+        "detail_lines",
         # SF-constrained: missing Vary fields come from Accept-CH Tokens
         "missing_fields",
         # SF dict keys: [a-z0-9_\-.*] only, no HTML special chars


### PR DESCRIPTION
## Summary

Adds GOOD-level notes recognizing well-configured response headers, plus
a couple of supporting WARN notes for misconfigurations they uncovered.

### Security headers
- `Referrer-Policy`: new `REFERRER_POLICY_STRICT` for `no-referrer`,
  `same-origin`, `strict-origin`, `strict-origin-when-cross-origin`.
- `Cross-Origin-Resource-Policy`: promote `same-origin` / `same-site`
  notes from INFO to GOOD (`cross-origin` stays INFO — intentional
  sharing).
- `X-Frame-Options`: promote DENY / SAMEORIGIN to GOOD, drop the
  obsolete IE8 framing, and note supersession by CSP `frame-ancestors`.
- `Set-Cookie`: new `SET_COOKIE_HARDENED` — a single consolidated note
  listing cookies that set Secure + HttpOnly + a non-`None` SameSite.
- `Clear-Site-Data`: new `CSD_PRESENT` listing the directives being
  cleared (only fires for valid, quoted values).

### Reporting
- `NEL`: new `NEL_CONFIGURED`. Gated to only fire when the policy
  itself has no errors (required keys present and well-typed; all
  optional values in range) *and* its `report_to` resolves to a
  `Reporting-Endpoints` entry whose URL is a string with a secure
  scheme (`https` / `wss`).

### Resource hints
- `Link`: new `LINK_RESOURCE_HINTS` summarising the `preload`,
  `preconnect`, and `dns-prefetch` hints in the response, listing
  targets per hint type. Multi-rel values like
  `rel="preconnect dns-prefetch"` are handled.
- New WARN-level `LINK_BAD_HINT_TARGET` flags hint targets that resolve
  to an unsupported scheme (e.g. `javascript:`, `ftp:`, `data:`) —
  browsers ignore them, so they're excluded from the positive note.

## Test plan

- [ ] `make tidy && make lint` — clean (pylint 10.00/10)
- [ ] `make typecheck` — clean
- [ ] `make test` — all new notes covered by tests; only the pre-existing
      `DeprecationDateTest` timezone failure remains (unrelated)
- [ ] Spot-check a real response (e.g. `curl -i https://www.mnot.net/ |
      httplint -n`) to confirm the new GOOD notes surface as expected