### PR TITLE
Fixed: strip backticks from interpolated detail vars by default

### DIFF
--- a/httplint/field/parsers/content_security_policy.py
+++ b/httplint/field/parsers/content_security_policy.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from httplint.field.list_field import HttpListField
 from httplint.field.tests import FieldTest
-from httplint.note import Note, categories, levels
+from httplint.note import MarkdownSafe, Note, categories, levels
 from httplint.syntax import rfc9110
 from httplint.types import (
     AddNoteMethodType,
@@ -174,8 +174,9 @@ sources of content that browsers are allowed to load on a page."""
                         report_only_text=self.report_only_text,
                     )
 
-    def _make_list(self, items: list[str]) -> str:
-        return "\n".join([f"* `{item}`" for item in items])
+    def _make_list(self, items: list[str]) -> MarkdownSafe:
+        safe = [item.replace("`", "") for item in items]
+        return MarkdownSafe("\n".join(f"* `{item}`" for item in safe))
 
 
 class CONTENT_SECURITY_POLICY(Note):

--- a/httplint/field/parsers/link.py
+++ b/httplint/field/parsers/link.py
@@ -6,7 +6,7 @@ from httplint.field import BAD_SYNTAX
 from httplint.field.list_field import HttpListField
 from httplint.field.tests import FieldTest
 from httplint.field.utils import PARAM_REPEATS, parse_params
-from httplint.note import Note, categories, levels
+from httplint.note import MarkdownSafe, Note, categories, levels
 from httplint.syntax import rfc3986, rfc8288, rfc9110
 from httplint.types import (
     AddNoteMethodType,
@@ -70,8 +70,6 @@ statement of the form "[context IRI] has a [relation type] resource at [target I
         present = {k: v for k, v in hints.items() if v}
         if present:
             hints_plain = ", ".join(present)
-            # Strip backticks so attacker-controlled link targets cannot escape
-            # the surrounding code span and inject raw HTML via Markdown.
             lines = []
             for rel_name, targets in present.items():
                 safe = [t.replace("`", "") for t in targets]
@@ -79,7 +77,7 @@ statement of the form "[context IRI] has a [relation type] resource at [target I
             add_note(
                 LINK_RESOURCE_HINTS,
                 hints=hints_plain,
-                detail_lines="\n".join(lines),
+                detail_lines=MarkdownSafe("\n".join(lines)),
             )
 
 

--- a/httplint/field/parsers/set_cookie.py
+++ b/httplint/field/parsers/set_cookie.py
@@ -6,7 +6,7 @@ from urllib.parse import urlsplit
 from httplint.field import RFC6265
 from httplint.field.broken_field import BrokenField
 from httplint.field.tests import FieldTest
-from httplint.note import Note, categories, levels
+from httplint.note import MarkdownSafe, Note, categories, levels
 from httplint.types import (
     AddNoteMethodType,
     DeferredNoteType,
@@ -58,11 +58,11 @@ requests to the server."""
 
         hardened = [name for name, _, attrs in self.value if _is_hardened(attrs)]
         if hardened:
-            # Strip backticks so attacker-controlled cookie names cannot escape
-            # the surrounding code span and inject raw HTML via Markdown.
             add_note(
                 SET_COOKIE_HARDENED,
-                cookie_names=", ".join(f"`{n.replace('`', '')}`" for n in hardened),
+                cookie_names=MarkdownSafe(
+                    ", ".join(f"`{n.replace('`', '')}`" for n in hardened)
+                ),
             )
 
         for note_adder, note, category, kwargs in self._deferred_notes:

--- a/httplint/note.py
+++ b/httplint/note.py
@@ -19,6 +19,18 @@ class _MdLocal(local):
 _md_local = _MdLocal()
 
 
+class MarkdownSafe(str):
+    """
+    Marker for var values that are pre-composed Markdown.
+
+    Note._get_detail strips backticks from interpolated var values so
+    wire-supplied data cannot close a code span and inject raw HTML.
+    Wrap a value in MarkdownSafe(...) when the backticks (or other
+    Markdown syntax) in the value were produced by library code and
+    must survive interpolation intact.
+    """
+
+
 def _get_markdown() -> Markdown:
     """Return a per-thread Markdown instance, creating it on first use."""
     if not hasattr(_md_local, "md"):
@@ -129,11 +141,22 @@ class Note:
         passed as plain strings; the Markdown renderer handles escaping.
         Template authors must wrap user-controlled vars in backtick code
         spans (or indented code blocks) so Markdown escapes them correctly.
+
+        As defense-in-depth, backticks are stripped from each interpolated
+        value so a wire-supplied backtick cannot close the surrounding
+        code span and let the rest of the value render as raw HTML.
+        Values that are pre-composed Markdown produced by library code
+        (e.g. a joined list of code spans) should be wrapped in
+        MarkdownSafe to opt out of this stripping.
         """
+        def _coerce(v: Any) -> str:
+            if isinstance(v, MarkdownSafe):
+                return str(v)
+            return str(v).replace("`", "")
+
+        safe_vars = {k: _coerce(v) for k, v in self.vars.items()}
         return Markup(
-            _get_markdown()
-            .reset()
-            .convert(translate(self._text) % {k: str(v) for k, v in self.vars.items()})
+            _get_markdown().reset().convert(translate(self._text) % safe_vars)
         )
 
     summary = property(_get_summary)

--- a/httplint/status.py
+++ b/httplint/status.py
@@ -4,6 +4,7 @@ from functools import partial
 from typing import List, Optional
 
 from httplint.note import Note, categories, levels
+from httplint.util import markdown_list
 from httplint.types import (
     RequestLinterProtocol,
     ResponseLinterProtocol,
@@ -135,7 +136,7 @@ class StatusChecker:
             self.add_note(
                 "field-content-type",
                 HEADER_SHOULD_NOT_BE_IN_304,
-                headers="\n".join([f"* `{h}`" for h in prohibited_headers]),
+                headers=markdown_list(prohibited_headers, markup="`"),
             )
 
     def status305(self) -> None:  # Use Proxy

--- a/httplint/util.py
+++ b/httplint/util.py
@@ -8,6 +8,7 @@ from urllib.parse import quote as urlquote
 from urllib.parse import urlsplit, urlunsplit
 
 from httplint.i18n import format_timedelta, translate
+from httplint.note import MarkdownSafe
 
 
 def iri_to_uri(iri: str) -> str:
@@ -57,11 +58,16 @@ def display_bytes(inbytes: bytes, encoding: str = "utf-8", truncate: int = 40) -
     return "".join(out)
 
 
-def markdown_list(inlist: List[str], markup: str = "") -> str:
+def markdown_list(inlist: List[str], markup: str = "") -> MarkdownSafe:
     """
-    Format a list of strings into markdown.
+    Format a list of strings into Markdown.
+
+    Each item has backticks stripped so wire-supplied content cannot
+    close the surrounding `markup` span. The result is MarkdownSafe so
+    Note._get_detail preserves the structural markup on interpolation.
     """
-    return "\n".join([f"- {markup}{i}{markup}" for i in inlist])
+    safe = [i.replace("`", "") for i in inlist]
+    return MarkdownSafe("\n".join(f"- {markup}{i}{markup}" for i in safe))
 
 
 class RelativeTime:


### PR DESCRIPTION
Note._get_detail now strips backticks from each interpolated var value before Markdown rendering, as defense-in-depth: even if a template author forgets to wrap a wire-supplied var in a code span — or wraps it correctly but the value contains a backtick — the value can no longer close the surrounding span and leak raw HTML through the Markdown renderer.

For values that are *pre-composed* Markdown produced by library code (e.g. a joined list of code spans whose backticks are structural), introduce MarkdownSafe(str): wrapping a value in MarkdownSafe opts out of the strip. Update SET_COOKIE_HARDENED.cookie_names and LINK_RESOURCE_HINTS.detail_lines to wrap their composed output; individual wire-supplied segments inside those composed strings are still backtick-stripped at the call site so they cannot break out of their own spans.

The static tools/check_detail_escaping.py checker is still needed for the orthogonal failure mode (vars in plain paragraph text with no backtick wrapping at all), which this runtime guard does not help with.