### PR TITLE
Added: support for Accept-Patch, Accept-Post, and Accept-Query

### DIFF
--- a/httplint/field/parsers/accept.py
+++ b/httplint/field/parsers/accept.py
@@ -74,10 +74,11 @@ The `q` parameter must be a decimal number between 0 and 1, with at most 3 digit
 class ACCEPT_BAD_SYNTAX(Note):
     category = categories.CONNEG
     level = levels.BAD
-    _summary = "The Accept header isn't valid."
+    _summary = "The Accept header contains a value that is not a media range."
     _text = """\
-The value for this field doesn't conform to its specified syntax; see [its
-definition](%(ref_uri)s) for more information."""
+`%(value)s` is not a valid media range. `Accept` is a list of media ranges
+(e.g., `text/html`, `image/*`, `*/*`) that the client prefers in the response;
+see [its definition](%(ref_uri)s) for more information."""
 
 
 class AcceptTest(FieldTest[RequestLinterProtocol]):

--- a/httplint/field/parsers/accept.py
+++ b/httplint/field/parsers/accept.py
@@ -4,7 +4,7 @@ from typing import Optional
 from httplint.field import BAD_SYNTAX
 from httplint.field.list_field import HttpListField
 from httplint.field.tests import FieldTest
-from httplint.field.utils import parse_params
+from httplint.field.utils import parse_media_type
 from httplint.note import Note, categories, levels
 from httplint.syntax import rfc9110
 from httplint.types import (
@@ -33,19 +33,14 @@ acceptable in responses."""
     deprecated = False
 
     def parse(self, field_value: str, add_note: AddNoteMethodType) -> AcceptValue:
-        try:
-            media_type, param_str = field_value.split(";", 1)
-        except ValueError:
-            media_type, param_str = field_value, ""
-
-        media_type = media_type.lower()
-        # check media type syntax?
-        # rfc9110.media_range is ( "*/*" / ( type "/*" ) / ( type "/" subtype ) )
-        # We assume regex pre-check might handle some, but simple split is safer.
-        if "/" not in media_type and media_type != "*":
-            add_note(ACCEPT_BAD_SYNTAX, ref_uri=self.reference)
-
-        param_dict = parse_params(param_str, add_note, ["q"], delim=";")
+        media_type, param_dict = parse_media_type(
+            field_value,
+            add_note,
+            ACCEPT_BAD_SYNTAX,
+            self.reference,
+            allow_wildcard=True,
+            nostar=["q"],
+        )
 
         q_val: Optional[float] = None
         if "q" in param_dict:

--- a/httplint/field/parsers/accept_patch.py
+++ b/httplint/field/parsers/accept_patch.py
@@ -1,0 +1,61 @@
+from typing import Tuple
+
+from httplint.field.list_field import HttpListField
+from httplint.field.tests import FieldTest
+from httplint.field.utils import parse_media_type
+from httplint.note import Note, categories, levels
+from httplint.types import (
+    AddNoteMethodType,
+    NoteClassListType,
+    ParamDictType,
+    ResponseLinterProtocol,
+)
+
+
+class accept_patch(HttpListField[ResponseLinterProtocol]):
+    canonical_name = "Accept-Patch"
+    description = """\
+The `Accept-Patch` response header advertises which media types are accepted by the server in a
+PATCH request."""
+    reference = "https://www.rfc-editor.org/rfc/rfc5789.html#section-3.1"
+    syntax = False
+    category = categories.GENERAL
+    deprecated = False
+
+    def parse(
+        self, field_value: str, add_note: AddNoteMethodType
+    ) -> Tuple[str, ParamDictType]:
+        return parse_media_type(
+            field_value, add_note, ACCEPT_PATCH_BAD_SYNTAX, self.reference
+        )
+
+
+class ACCEPT_PATCH_BAD_SYNTAX(Note):
+    category = categories.GENERAL
+    level = levels.BAD
+    _summary = "The Accept-Patch header isn't valid."
+    _text = """\
+The value for this field doesn't conform to its specified syntax; see [its
+definition](%(ref_uri)s) for more information."""
+
+
+class AcceptPatchTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Patch"
+    inputs = [b"application/json-patch+json, application/merge-patch+json"]
+    expected_out = [
+        ("application/json-patch+json", {}),
+        ("application/merge-patch+json", {}),
+    ]
+
+
+class AcceptPatchParamsTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Patch"
+    inputs = [b"text/example;charset=utf-8"]
+    expected_out = [("text/example", {"charset": "utf-8"})]
+
+
+class AcceptPatchBadTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Patch"
+    inputs = [b"invalid"]
+    expected_out = [("invalid", {})]
+    expected_notes: NoteClassListType = [ACCEPT_PATCH_BAD_SYNTAX]

--- a/httplint/field/parsers/accept_patch.py
+++ b/httplint/field/parsers/accept_patch.py
@@ -33,9 +33,10 @@ PATCH request."""
 class ACCEPT_PATCH_BAD_SYNTAX(Note):
     category = categories.GENERAL
     level = levels.BAD
-    _summary = "The Accept-Patch header isn't valid."
+    _summary = "The Accept-Patch header contains a value that is not a media type."
     _text = """\
-The value for this field doesn't conform to its specified syntax; see [its
+`%(value)s` is not a valid media type. `Accept-Patch` is a list of media types
+(e.g., `application/json-patch+json`) accepted in a PATCH request; see [its
 definition](%(ref_uri)s) for more information."""
 
 

--- a/httplint/field/parsers/accept_post.py
+++ b/httplint/field/parsers/accept_post.py
@@ -37,10 +37,11 @@ POST request."""
 class ACCEPT_POST_BAD_SYNTAX(Note):
     category = categories.GENERAL
     level = levels.BAD
-    _summary = "The Accept-Post header isn't valid."
+    _summary = "The Accept-Post header contains a value that is not a media type."
     _text = """\
-The value for this field doesn't conform to its specified syntax; see [its
-definition](%(ref_uri)s) for more information."""
+`%(value)s` is not a valid media type. `Accept-Post` is a list of media types
+(e.g., `text/turtle`) accepted in a POST request; see [its definition](%(ref_uri)s)
+for more information."""
 
 
 class AcceptPostTest(FieldTest[ResponseLinterProtocol]):

--- a/httplint/field/parsers/accept_post.py
+++ b/httplint/field/parsers/accept_post.py
@@ -1,0 +1,62 @@
+from typing import Tuple
+
+from httplint.field.list_field import HttpListField
+from httplint.field.tests import FieldTest
+from httplint.field.utils import parse_media_type
+from httplint.note import Note, categories, levels
+from httplint.types import (
+    AddNoteMethodType,
+    NoteClassListType,
+    ParamDictType,
+    ResponseLinterProtocol,
+)
+
+
+class accept_post(HttpListField[ResponseLinterProtocol]):
+    canonical_name = "Accept-Post"
+    description = """\
+The `Accept-Post` response header advertises which media types are accepted by the server in a
+POST request."""
+    reference = "https://www.w3.org/TR/ldp/#header-accept-post"
+    syntax = False
+    category = categories.GENERAL
+    deprecated = False
+
+    def parse(
+        self, field_value: str, add_note: AddNoteMethodType
+    ) -> Tuple[str, ParamDictType]:
+        return parse_media_type(
+            field_value,
+            add_note,
+            ACCEPT_POST_BAD_SYNTAX,
+            self.reference,
+            allow_wildcard=True,
+        )
+
+
+class ACCEPT_POST_BAD_SYNTAX(Note):
+    category = categories.GENERAL
+    level = levels.BAD
+    _summary = "The Accept-Post header isn't valid."
+    _text = """\
+The value for this field doesn't conform to its specified syntax; see [its
+definition](%(ref_uri)s) for more information."""
+
+
+class AcceptPostTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Post"
+    inputs = [b"text/turtle, application/ld+json"]
+    expected_out = [("text/turtle", {}), ("application/ld+json", {})]
+
+
+class AcceptPostWildcardTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Post"
+    inputs = [b"*/*"]
+    expected_out = [("*/*", {})]
+
+
+class AcceptPostBadTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Post"
+    inputs = [b"invalid"]
+    expected_out = [("invalid", {})]
+    expected_notes: NoteClassListType = [ACCEPT_POST_BAD_SYNTAX]

--- a/httplint/field/parsers/accept_query.py
+++ b/httplint/field/parsers/accept_query.py
@@ -1,0 +1,58 @@
+from typing import Tuple
+
+from httplint.field.list_field import HttpListField
+from httplint.field.tests import FieldTest
+from httplint.field.utils import parse_media_type
+from httplint.note import Note, categories, levels
+from httplint.types import (
+    AddNoteMethodType,
+    NoteClassListType,
+    ParamDictType,
+    ResponseLinterProtocol,
+)
+
+
+class accept_query(HttpListField[ResponseLinterProtocol]):
+    canonical_name = "Accept-Query"
+    description = """\
+The `Accept-Query` response header advertises which media types are accepted by the server in the
+content of a QUERY request."""
+    reference = "https://www.rfc-editor.org/rfc/rfc9694.html#section-3"
+    syntax = False
+    category = categories.GENERAL
+    deprecated = False
+
+    def parse(
+        self, field_value: str, add_note: AddNoteMethodType
+    ) -> Tuple[str, ParamDictType]:
+        return parse_media_type(
+            field_value, add_note, ACCEPT_QUERY_BAD_SYNTAX, self.reference
+        )
+
+
+class ACCEPT_QUERY_BAD_SYNTAX(Note):
+    category = categories.GENERAL
+    level = levels.BAD
+    _summary = "The Accept-Query header isn't valid."
+    _text = """\
+The value for this field doesn't conform to its specified syntax; see [its
+definition](%(ref_uri)s) for more information."""
+
+
+class AcceptQueryTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Query"
+    inputs = [b"application/sparql-query, application/sql"]
+    expected_out = [("application/sparql-query", {}), ("application/sql", {})]
+
+
+class AcceptQueryParamsTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Query"
+    inputs = [b"application/example;version=1"]
+    expected_out = [("application/example", {"version": "1"})]
+
+
+class AcceptQueryBadTest(FieldTest[ResponseLinterProtocol]):
+    name = "Accept-Query"
+    inputs = [b"invalid"]
+    expected_out = [("invalid", {})]
+    expected_notes: NoteClassListType = [ACCEPT_QUERY_BAD_SYNTAX]

--- a/httplint/field/parsers/accept_query.py
+++ b/httplint/field/parsers/accept_query.py
@@ -17,7 +17,10 @@ class accept_query(HttpListField[ResponseLinterProtocol]):
     description = """\
 The `Accept-Query` response header advertises which media types are accepted by the server in the
 content of a QUERY request."""
-    reference = "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-safe-method-w-body#section-3"
+    reference = (
+        "https://datatracker.ietf.org/doc/html/"
+        "draft-ietf-httpbis-safe-method-w-body#section-3"
+    )
     syntax = False
     category = categories.GENERAL
     deprecated = False

--- a/httplint/field/parsers/accept_query.py
+++ b/httplint/field/parsers/accept_query.py
@@ -17,7 +17,7 @@ class accept_query(HttpListField[ResponseLinterProtocol]):
     description = """\
 The `Accept-Query` response header advertises which media types are accepted by the server in the
 content of a QUERY request."""
-    reference = "https://www.rfc-editor.org/rfc/rfc9694.html#section-3"
+    reference = "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-safe-method-w-body#section-3"
     syntax = False
     category = categories.GENERAL
     deprecated = False

--- a/httplint/field/parsers/accept_query.py
+++ b/httplint/field/parsers/accept_query.py
@@ -36,10 +36,11 @@ content of a QUERY request."""
 class ACCEPT_QUERY_BAD_SYNTAX(Note):
     category = categories.GENERAL
     level = levels.BAD
-    _summary = "The Accept-Query header isn't valid."
+    _summary = "The Accept-Query header contains a value that is not a media type."
     _text = """\
-The value for this field doesn't conform to its specified syntax; see [its
-definition](%(ref_uri)s) for more information."""
+`%(value)s` is not a valid media type. `Accept-Query` is a list of media types
+(e.g., `application/sparql-query`) accepted in the content of a QUERY request;
+see [its definition](%(ref_uri)s) for more information."""
 
 
 class AcceptQueryTest(FieldTest[ResponseLinterProtocol]):

--- a/httplint/field/parsers/content_type.py
+++ b/httplint/field/parsers/content_type.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 from httplint.field.singleton_field import SingletonField
 from httplint.field.tests import FieldTest
-from httplint.field.utils import parse_params
+from httplint.field.utils import parse_media_type
 from httplint.syntax import rfc9110
 from httplint.types import (
     AddNoteMethodType,
@@ -22,13 +22,7 @@ a GET."""
     deprecated = False
 
     def parse(self, field_value: str, add_note: AddNoteMethodType) -> Tuple[str, ParamDictType]:
-        try:
-            media_type, param_str = field_value.split(";", 1)
-        except ValueError:
-            media_type, param_str = field_value, ""
-        media_type = media_type.lower()
-        param_dict = parse_params(param_str, add_note, ["charset"])
-        return media_type, param_dict
+        return parse_media_type(field_value, add_note, nostar=["charset"])
 
 
 class BasicCTTest(FieldTest[AnyMessageLinterProtocol]):

--- a/httplint/field/utils.py
+++ b/httplint/field/utils.py
@@ -1,7 +1,7 @@
 import calendar
 import re
 from email.utils import parsedate as lib_parsedate
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from urllib.parse import unquote as urlunquote
 
 from http_sf import Token
@@ -9,6 +9,38 @@ from http_sf import Token
 from httplint.note import Note, categories, levels
 from httplint.syntax import rfc9110
 from httplint.types import AddNoteMethodType, ParamDictType
+
+
+def parse_media_type(
+    field_value: str,
+    add_note: AddNoteMethodType,
+    bad_syntax_note: Optional[Type[Note]] = None,
+    ref_uri: Optional[str] = None,
+    allow_wildcard: bool = False,
+    nostar: Optional[Union[List[str], bool]] = None,
+) -> Tuple[str, ParamDictType]:
+    """
+    Parse a media-type with optional parameters (e.g. ``text/html;charset=utf-8``).
+
+    Returns a tuple of the lowercased media-type and its parameter dict. If
+    ``bad_syntax_note`` is provided, it is emitted (with ``ref_uri`` if given)
+    when the media-type lacks a ``/``. When ``allow_wildcard`` is true, a bare
+    ``*`` is accepted without a note. ``nostar`` is passed through to
+    ``parse_params`` to flag RFC 5987-style ``param*`` keys.
+    """
+    try:
+        media_type, param_str = field_value.split(";", 1)
+    except ValueError:
+        media_type, param_str = field_value, ""
+    media_type = media_type.strip().lower()
+    if "/" not in media_type and not (allow_wildcard and media_type == "*"):
+        if bad_syntax_note is not None:
+            if ref_uri is not None:
+                add_note(bad_syntax_note, ref_uri=ref_uri)
+            else:
+                add_note(bad_syntax_note)
+    param_dict = parse_params(param_str, add_note, nostar)
+    return media_type, param_dict
 
 RE_FLAGS = re.VERBOSE | re.IGNORECASE
 

--- a/httplint/field/utils.py
+++ b/httplint/field/utils.py
@@ -35,10 +35,10 @@ def parse_media_type(
     media_type = media_type.strip().lower()
     if "/" not in media_type and not (allow_wildcard and media_type == "*"):
         if bad_syntax_note is not None:
+            kwargs: Dict[str, Any] = {"value": media_type}
             if ref_uri is not None:
-                add_note(bad_syntax_note, ref_uri=ref_uri)
-            else:
-                add_note(bad_syntax_note)
+                kwargs["ref_uri"] = ref_uri
+            add_note(bad_syntax_note, **kwargs)
     param_dict = parse_params(param_str, add_note, nostar)
     return media_type, param_dict
 


### PR DESCRIPTION
Each is a response header listing media types accepted in PATCH, POST, or QUERY request content (RFC 5789, W3C LDP, and RFC 9694 respectively).

Also factored shared media-type parsing into parse_media_type() in field/utils.py, and switched Content-Type and Accept to use it.

Closes #95.