### PR TITLE
Added: chardet-based check for Content-Type charset mismatches

### DIFF
--- a/httplint/charset.py
+++ b/httplint/charset.py
@@ -1,0 +1,174 @@
+import codecs
+from typing import Optional
+
+import chardet
+
+from httplint.note import Note, categories, levels
+from httplint.types import LinterProtocol
+
+# Confidence threshold below which chardet results are ignored. chardet
+# is conservative on Cyrillic/CJK (often 0.5–0.7) but the secondary
+# _encodings_compatible check below filters out cases where the
+# different name still decodes to the same text.
+CHARDET_CONFIDENCE_THRESHOLD = 0.5
+
+
+def _requires_utf8(media_type: str) -> bool:
+    """
+    True for media types whose definition mandates UTF-8. RFC 8259 requires
+    UTF-8 for all JSON texts; by IANA convention this applies to any
+    `+json` structured-syntax-suffix type as well.
+    """
+    if media_type in ("application/json", "text/json"):
+        return True
+    subtype = media_type.split("/", 1)[-1]
+    return subtype.endswith("+json")
+
+
+def _canonical(name: str) -> Optional[str]:
+    try:
+        return codecs.lookup(name).name
+    except (LookupError, TypeError):
+        return None
+
+
+def verify_charset(linter: LinterProtocol) -> None:  # pylint: disable=too-many-return-statements
+    """
+    Verify that the content's character encoding matches what was declared
+    (or implied) by the Content-Type header.
+    """
+    if not linter.content_hash or not linter.content_sample:
+        return
+
+    status_code = getattr(linter, "status_code", None)
+    if status_code in [204, 205, 304, 206] + list(range(100, 199)) or getattr(
+        linter, "is_head_response", False
+    ):
+        return
+
+    if "content-type" not in linter.headers.parsed:
+        return
+    declared_type = linter.headers.parsed["content-type"][0]
+    params = linter.headers.parsed["content-type"][1]
+    if not declared_type:
+        return
+
+    declared_charset_raw = params.get("charset")
+    if _requires_utf8(declared_type):
+        # JSON et al. are always UTF-8 per RFC 8259; any charset parameter
+        # is ignored by recipients.
+        effective_charset_raw = "utf-8"
+        is_implicit = declared_charset_raw is None
+    elif declared_type.startswith("text/") and declared_charset_raw:
+        effective_charset_raw = declared_charset_raw
+        is_implicit = False
+    else:
+        # No declared or implied charset; nothing to check against.
+        return
+
+    declared_canonical = _canonical(effective_charset_raw)
+    if declared_canonical is None:
+        # Unknown declared encoding; another check reports this.
+        return
+
+    sample = linter.content_sample
+    if not sample.strip():
+        return
+
+    # Pure-ASCII content is compatible with every ASCII-superset encoding;
+    # don't second-guess it.
+    if not any(b & 0x80 for b in sample):
+        return
+
+    # Primary check: does the declared encoding actually decode the content?
+    try:
+        sample.decode(effective_charset_raw, errors="strict")
+        decodes = True
+    except (UnicodeDecodeError, LookupError):
+        decodes = False
+
+    detection = chardet.detect(sample)
+    detected_raw = detection.get("encoding")
+    confidence = detection.get("confidence") or 0.0
+    detected_canonical = _canonical(detected_raw) if detected_raw else None
+
+    if not decodes:
+        linter.notes.add(
+            "content-type",
+            CHARSET_UNDECODABLE,
+            declared_charset=effective_charset_raw,
+            detected_charset=detected_raw or "unknown",
+        )
+        return
+
+    if (
+        detected_canonical
+        and detected_canonical != declared_canonical
+        and confidence >= CHARDET_CONFIDENCE_THRESHOLD
+        and not _encodings_compatible(declared_canonical, detected_canonical, sample)
+    ):
+        if is_implicit:
+            linter.notes.add(
+                "content-type",
+                CHARSET_IMPLICIT_MISMATCH,
+                media_type=declared_type,
+                declared_charset=effective_charset_raw,
+                detected_charset=detected_raw,
+            )
+        else:
+            linter.notes.add(
+                "content-type",
+                CHARSET_MISMATCH,
+                declared_charset=effective_charset_raw,
+                detected_charset=detected_raw,
+            )
+
+
+def _encodings_compatible(declared: str, detected: str, sample: bytes) -> bool:
+    """
+    Return True if decoding `sample` with `declared` and with `detected`
+    yields the same text. This catches cases where chardet picks a
+    different name (e.g. windows-1252 vs iso-8859-1) for content that is
+    identical under both.
+    """
+    try:
+        a = sample.decode(declared, errors="strict")
+        b = sample.decode(detected, errors="strict")
+    except (UnicodeDecodeError, LookupError):
+        return False
+    return a == b
+
+
+class CHARSET_MISMATCH(Note):
+    category = categories.GENERAL
+    level = levels.WARN
+    _summary = "The declared character encoding doesn't match the content."
+    _text = """\
+The `Content-Type` header declares the character encoding as `%(declared_charset)s`,
+but the content appears to be encoded as `%(detected_charset)s`.
+
+Recipients that trust the declared charset might misinterpret the content."""
+
+
+class CHARSET_IMPLICIT_MISMATCH(Note):
+    category = categories.GENERAL
+    level = levels.WARN
+    _summary = "The content isn't %(declared_charset)s, as required for %(media_type)s."
+    _text = """\
+The `%(media_type)s` media type requires content to be encoded as
+`%(declared_charset)s`, but the content appears to be `%(detected_charset)s`.
+
+Recipients might interpret this content as `%(declared_charset)s` regardless
+of what was sent, so non-ASCII characters may be misrendered."""
+
+
+class CHARSET_UNDECODABLE(Note):
+    category = categories.GENERAL
+    level = levels.BAD
+    _summary = "The content can't be decoded using the declared character encoding."
+    _text = """\
+The content was declared as `%(declared_charset)s` (either explicitly or by
+the media type's definition), but it cannot be decoded using that encoding;
+it looks more like `%(detected_charset)s`.
+
+This will likely cause decoding errors in recipients."""

--- a/httplint/message.py
+++ b/httplint/message.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, TypedDict, cast
 from typing_extensions import NotRequired, Unpack
 
 from httplint.cache import ResponseCacheChecker
+from httplint.charset import verify_charset
 from httplint.content_encoding import ContentEncodingProcessor
 from httplint.content_type import verify_content_type
 from httplint.field.cors import check_preflight_request, check_preflight_response
@@ -165,12 +166,14 @@ class HttpMessageLinter:
     def post_checks(self) -> None:
         "Post-parsing checks to perform."
 
+    content_sample_size = 8192
+
     def _content_sample_processor(self, chunk: bytes) -> None:
         """
         Capture a sample of the decoded content.
         """
-        if len(self.content_sample) < 1024:
-            self.content_sample += chunk[: 1024 - len(self.content_sample)]
+        if len(self.content_sample) < self.content_sample_size:
+            self.content_sample += chunk[: self.content_sample_size - len(self.content_sample)]
 
     def __repr__(self) -> str:
         status = [self.__class__.__module__ + "." + self.__class__.__name__]
@@ -307,6 +310,7 @@ class HttpResponseLinter(HttpMessageLinter):
         StatusChecker(self, self.request)
         if not self.no_content:
             verify_content_type(self)
+            verify_charset(self)
 
 
 class CL_CORRECT(Note):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "sniffpy==1.0.0",
     "Babel",
     "Brotli",
+    "chardet",
 ]
 
 [project.optional-dependencies]

--- a/test/test_charset.py
+++ b/test/test_charset.py
@@ -1,0 +1,92 @@
+import unittest
+
+from httplint.charset import (
+    CHARSET_IMPLICIT_MISMATCH,
+    CHARSET_MISMATCH,
+    CHARSET_UNDECODABLE,
+)
+from httplint.message import HttpResponseLinter
+
+
+def _run(headers, body):
+    linter = HttpResponseLinter()
+    linter.process_response_topline(b"HTTP/1.1", b"200", b"OK")
+    linter.process_headers(headers + [(b"Content-Length", str(len(body)).encode())])
+    linter.feed_content(body)
+    linter.finish_content(True)
+    return linter
+
+
+def _has_note(notes, cls):
+    return any(isinstance(n, cls) for n in notes)
+
+
+class CharsetTest(unittest.TestCase):
+    def test_no_charset_no_note(self):
+        body = "Hello world! Café and résumé.".encode("utf-8")
+        linter = _run([(b"Content-Type", b"text/plain")], body)
+        self.assertFalse(_has_note(linter.notes, CHARSET_MISMATCH))
+        self.assertFalse(_has_note(linter.notes, CHARSET_UNDECODABLE))
+
+    def test_pure_ascii_no_note(self):
+        body = b"Hello world, this is plain ASCII text only."
+        linter = _run(
+            [(b"Content-Type", b"text/plain; charset=utf-8")],
+            body,
+        )
+        self.assertFalse(_has_note(linter.notes, CHARSET_MISMATCH))
+
+    def test_utf8_matches_declared(self):
+        body = ("Café résumé naïve " * 50).encode("utf-8")
+        linter = _run(
+            [(b"Content-Type", b"text/plain; charset=utf-8")],
+            body,
+        )
+        self.assertFalse(_has_note(linter.notes, CHARSET_MISMATCH))
+        self.assertFalse(_has_note(linter.notes, CHARSET_UNDECODABLE))
+
+    def test_utf8_declared_but_latin1_content(self):
+        body = ("Café résumé naïve garçon " * 80).encode("latin-1")
+        linter = _run(
+            [(b"Content-Type", b"text/plain; charset=utf-8")],
+            body,
+        )
+        # latin-1 bytes (0xE9 etc.) are not valid utf-8 continuation bytes
+        self.assertTrue(_has_note(linter.notes, CHARSET_UNDECODABLE))
+
+    def test_json_implicit_utf8_mismatch(self):
+        body = '{"name": "Café résumé"}'.encode("latin-1") * 30
+        linter = _run([(b"Content-Type", b"application/json")], body)
+        self.assertTrue(_has_note(linter.notes, CHARSET_UNDECODABLE))
+
+    def test_json_ascii_ok(self):
+        body = b'{"name": "value"}' * 20
+        linter = _run([(b"Content-Type", b"application/json")], body)
+        self.assertFalse(_has_note(linter.notes, CHARSET_UNDECODABLE))
+        self.assertFalse(_has_note(linter.notes, CHARSET_IMPLICIT_MISMATCH))
+
+    def test_mismatch_decodable_but_wrong(self):
+        # Russian text in windows-1251. Declaring iso-8859-1 "works"
+        # (latin-1 decodes any byte) but produces gibberish.
+        russian = (
+            "Привет мир! "
+            "Это длинный русский текст для проверки определения кодировки. "
+            "Москва Санкт-Петербург Новосибирск Екатеринбург Казань. "
+            "Литература наука культура история философия. "
+        ) * 50
+        body = russian.encode("windows-1251")
+        linter = _run(
+            [(b"Content-Type", b"text/plain; charset=iso-8859-1")],
+            body,
+        )
+        self.assertTrue(_has_note(linter.notes, CHARSET_MISMATCH))
+
+    def test_plus_json_requires_utf8(self):
+        # +json subtypes inherit JSON's UTF-8 requirement per RFC 8259.
+        body = '{"name": "Café résumé"}'.encode("latin-1") * 30
+        linter = _run([(b"Content-Type", b"application/vnd.api+json")], body)
+        self.assertTrue(_has_note(linter.notes, CHARSET_UNDECODABLE))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a post-content check that compares the declared (or implied) character encoding against what chardet detects in the content sample. Three new notes are emitted:

- CHARSET_UNDECODABLE (BAD): the declared encoding cannot decode the content. Always fires for application/json, text/json, and any `+json` subtype whose bytes are not valid UTF-8, as RFC 8259 requires UTF-8 for all JSON texts.
- CHARSET_MISMATCH (WARN): the declared encoding decodes the content but chardet confidently reports a different encoding whose decode yields different text (e.g. windows-1251 mislabelled as ISO-8859-1).
- CHARSET_IMPLICIT_MISMATCH (WARN): same, but for media types whose charset is implied rather than parameter-declared.

Pure-ASCII samples and encodings that decode to the same text under both names are exempted to avoid false positives. The content sample captured by the linter is increased from 1024 to 8192 bytes to give chardet enough material to work with.

Closes #141.